### PR TITLE
Odradjen DTO,Controller,Service

### DIFF
--- a/src/Explorer.API/Controllers/Administrator/Administration/FacilityController.cs
+++ b/src/Explorer.API/Controllers/Administrator/Administration/FacilityController.cs
@@ -1,0 +1,45 @@
+using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Tours.API.Dtos;
+using Explorer.Tours.API.Public.Administration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Explorer.API.Controllers.Administrator.Administration;
+
+[Authorize(Policy = "administratorPolicy")]
+[Route("api/administration/facility")]
+[ApiController]
+public class FacilityController : ControllerBase
+{
+    private readonly IFacilityService _facilityService;
+
+    public FacilityController(IFacilityService facilityService)
+    {
+        _facilityService = facilityService;
+    }
+
+    [HttpGet]
+    public ActionResult<PagedResult<FacilityDto>> GetAll([FromQuery] int page, [FromQuery] int pageSize)
+    {
+        return Ok(_facilityService.GetPaged(page, pageSize));
+    }
+
+    [HttpPost]
+    public ActionResult<FacilityDto> Create([FromBody] FacilityDto facility)
+    {
+        return Ok(_facilityService.Create(facility));
+    }
+
+    [HttpPut("{id:long}")]
+    public ActionResult<FacilityDto> Update([FromBody] FacilityDto facility)
+    {
+        return Ok(_facilityService.Update(facility));
+    }
+
+    [HttpDelete("{id:long}")]
+    public ActionResult Delete(long id)
+    {
+        _facilityService.Delete(id);
+        return Ok();
+    }
+}

--- a/src/Modules/Tours/Explorer.Tours.API/Dtos/FacilityDto.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Dtos/FacilityDto.cs
@@ -1,0 +1,21 @@
+namespace Explorer.Tours.API.Dtos;
+
+public enum FacilityCategory
+{
+    WC,
+    Restaurant,
+    Parking,
+    Other
+}
+
+public class FacilityDto
+{
+    public long Id { get; set; }
+    public string Name { get; set; }
+    public double Latitude { get; set; }
+    public double Longitude { get; set; }
+    public FacilityCategory Category { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public bool IsDeleted { get; set; }
+}

--- a/src/Modules/Tours/Explorer.Tours.API/Public/Administration/IFacilityService.cs
+++ b/src/Modules/Tours/Explorer.Tours.API/Public/Administration/IFacilityService.cs
@@ -1,0 +1,12 @@
+using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Tours.API.Dtos;
+
+namespace Explorer.Tours.API.Public.Administration;
+
+public interface IFacilityService
+{
+    PagedResult<FacilityDto> GetPaged(int page, int pageSize);
+    FacilityDto Create(FacilityDto facility);
+    FacilityDto Update(FacilityDto facility);
+    void Delete(long id);
+}

--- a/src/Modules/Tours/Explorer.Tours.Core/Domain/Facility.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Domain/Facility.cs
@@ -1,0 +1,57 @@
+using Explorer.BuildingBlocks.Core.Domain;
+
+namespace Explorer.Tours.Core.Domain;
+
+public enum FacilityCategory
+{
+    WC,
+    Restaurant,
+    Parking,
+    Other
+}
+
+public class Facility : Entity
+{
+    public string Name { get; private set; }
+    public double Latitude { get; private set; }
+    public double Longitude { get; private set; }
+    public FacilityCategory Category { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
+    public bool IsDeleted { get; private set; }
+
+    public Facility(string name, double latitude, double longitude, FacilityCategory category)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name cannot be empty.");
+        if (latitude < -90 || latitude > 90) throw new ArgumentException("Latitude must be between -90 and 90.");
+        if (longitude < -180 || longitude > 180) throw new ArgumentException("Longitude must be between -180 and 180.");
+
+        Name = name;
+        Latitude = latitude;
+        Longitude = longitude;
+        Category = category;
+        CreatedAt = DateTime.UtcNow;
+        IsDeleted = false;
+    }
+
+    // Private constructor for EF Core
+    private Facility() { }
+
+    public void Update(string name, double latitude, double longitude, FacilityCategory category)
+    {
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Name cannot be empty.");
+        if (latitude < -90 || latitude > 90) throw new ArgumentException("Latitude must be between -90 and 90.");
+        if (longitude < -180 || longitude > 180) throw new ArgumentException("Longitude must be between -180 and 180.");
+
+        Name = name;
+        Latitude = latitude;
+        Longitude = longitude;
+        Category = category;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void MarkAsDeleted()
+    {
+        IsDeleted = true;
+    }
+}

--- a/src/Modules/Tours/Explorer.Tours.Core/Domain/RepositoryInterfaces/IFacilityRepository.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Domain/RepositoryInterfaces/IFacilityRepository.cs
@@ -1,0 +1,13 @@
+using Explorer.BuildingBlocks.Core.UseCases;
+
+namespace Explorer.Tours.Core.Domain.RepositoryInterfaces;
+
+public interface IFacilityRepository
+{
+    PagedResult<Facility> GetPaged(int page, int pageSize);
+    Facility Get(long id);
+    Facility Create(Facility facility);
+    Facility Update(Facility facility);
+    void Delete(long id);
+    bool ExistsByName(string name);
+}

--- a/src/Modules/Tours/Explorer.Tours.Core/Mappers/ToursProfile.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/Mappers/ToursProfile.cs
@@ -10,5 +10,6 @@ public class ToursProfile : Profile
     {
         CreateMap<EquipmentDto, Equipment>().ReverseMap();
         CreateMap<ProblemDto, Problem>().ReverseMap();
+        CreateMap<FacilityDto, Facility>().ReverseMap();
     }
 }

--- a/src/Modules/Tours/Explorer.Tours.Core/UseCases/Administration/FacilityService.cs
+++ b/src/Modules/Tours/Explorer.Tours.Core/UseCases/Administration/FacilityService.cs
@@ -1,0 +1,57 @@
+using AutoMapper;
+using Explorer.BuildingBlocks.Core.Exceptions;
+using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Tours.API.Dtos;
+using Explorer.Tours.API.Public.Administration;
+using Explorer.Tours.Core.Domain;
+using Explorer.Tours.Core.Domain.RepositoryInterfaces;
+using DomainFacilityCategory = Explorer.Tours.Core.Domain.FacilityCategory;
+
+namespace Explorer.Tours.Core.UseCases.Administration;
+
+public class FacilityService : IFacilityService
+{
+    private readonly IFacilityRepository _facilityRepository;
+    private readonly IMapper _mapper;
+
+    public FacilityService(IFacilityRepository repository, IMapper mapper)
+    {
+        _facilityRepository = repository;
+        _mapper = mapper;
+    }
+
+    public PagedResult<FacilityDto> GetPaged(int page, int pageSize)
+    {
+        var result = _facilityRepository.GetPaged(page, pageSize);
+        var items = result.Results.Select(_mapper.Map<FacilityDto>).ToList();
+        return new PagedResult<FacilityDto>(items, result.TotalCount);
+    }
+
+    public FacilityDto Create(FacilityDto facilityDto)
+    {
+        if (_facilityRepository.ExistsByName(facilityDto.Name))
+        {
+            throw new EntityValidationException("Facility with this name already exists.");
+        }
+
+        var facility = new Facility(facilityDto.Name, facilityDto.Latitude, facilityDto.Longitude, 
+            (DomainFacilityCategory)facilityDto.Category);
+        var result = _facilityRepository.Create(facility);
+        return _mapper.Map<FacilityDto>(result);
+    }
+
+    public FacilityDto Update(FacilityDto facilityDto)
+    {
+        var facility = _facilityRepository.Get(facilityDto.Id);
+        facility.Update(facilityDto.Name, facilityDto.Latitude, facilityDto.Longitude, 
+            (DomainFacilityCategory)facilityDto.Category);
+        
+        var result = _facilityRepository.Update(facility);
+        return _mapper.Map<FacilityDto>(result);
+    }
+
+    public void Delete(long id)
+    {
+        _facilityRepository.Delete(id);
+    }
+}

--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/ToursContext.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/ToursContext.cs
@@ -7,6 +7,7 @@ public class ToursContext : DbContext
 {
     public DbSet<Equipment> Equipment { get; set; }
     public DbSet<Problem> Problem { get; set; }
+    public DbSet<Facility> Facility { get; set; }
 
     public ToursContext(DbContextOptions<ToursContext> options) : base(options) {}
 

--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/ToursStartup.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/ToursStartup.cs
@@ -26,12 +26,14 @@ public static class ToursStartup
     {
         services.AddScoped<IEquipmentService, EquipmentService>();
         services.AddScoped<IProblemService, ProblemService>();
+        services.AddScoped<IFacilityService, FacilityService>();
     }
 
     private static void SetupInfrastructure(IServiceCollection services)
     {
         services.AddScoped<IEquipmentRepository, EquipmentDbRepository>();
         services.AddScoped<IProblemRepository, ProblemDbRepository>();
+        services.AddScoped<IFacilityRepository, FacilityDbRepository>();
 
         var dataSourceBuilder = new NpgsqlDataSourceBuilder(DbConnectionStringBuilder.Build("tours"));
         dataSourceBuilder.EnableDynamicJson();

--- a/src/Modules/Tours/Explorer.Tours.Tests/Integration/Administration/FacilityCommandTests.cs
+++ b/src/Modules/Tours/Explorer.Tours.Tests/Integration/Administration/FacilityCommandTests.cs
@@ -1,0 +1,205 @@
+using Explorer.API.Controllers.Administrator.Administration;
+using Explorer.BuildingBlocks.Core.Exceptions;
+using Explorer.Tours.API.Dtos;
+using Explorer.Tours.API.Public.Administration;
+using Explorer.Tours.Infrastructure.Database;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Explorer.Tours.Tests.Integration.Administration;
+
+[Collection("Sequential")]
+public class FacilityCommandTests : BaseToursIntegrationTest
+{
+    public FacilityCommandTests(ToursTestFactory factory) : base(factory) { }
+
+    [Fact]
+    public void Creates()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
+        var newEntity = new FacilityDto
+        {
+            Name = "Museum Parking Lot",
+            Latitude = 40.779437,
+            Longitude = -73.963244,
+            Category = API.Dtos.FacilityCategory.Parking
+        };
+
+        // Act
+        var result = ((ObjectResult)controller.Create(newEntity).Result)?.Value as FacilityDto;
+
+        // Assert - Response
+        result.ShouldNotBeNull();
+        result.Id.ShouldNotBe(0);
+        result.Name.ShouldBe(newEntity.Name);
+        result.Latitude.ShouldBe(newEntity.Latitude);
+        result.Longitude.ShouldBe(newEntity.Longitude);
+        result.Category.ShouldBe(newEntity.Category);
+        
+        // Assert - Database
+        var storedEntity = dbContext.Facility.FirstOrDefault(i => i.Name == newEntity.Name);
+        storedEntity.ShouldNotBeNull();
+        storedEntity.Id.ShouldBe(result.Id);
+    }
+
+    [Fact]
+    public void Create_fails_invalid_name()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var updatedEntity = new FacilityDto
+        {
+            Name = "",
+            Latitude = 40.779437,
+            Longitude = -73.963244,
+            Category = API.Dtos.FacilityCategory.WC
+        };
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => controller.Create(updatedEntity));
+    }
+
+    [Fact]
+    public void Create_fails_invalid_coordinates()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var invalidLatitude = new FacilityDto
+        {
+            Name = "Invalid Facility",
+            Latitude = 95.0, // Invalid latitude
+            Longitude = -73.963244,
+            Category = API.Dtos.FacilityCategory.WC
+        };
+
+        // Act & Assert
+        Should.Throw<ArgumentException>(() => controller.Create(invalidLatitude));
+    }
+
+    [Fact]
+    public void Create_fails_duplicate_name()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
+        
+        // First, create a facility
+        var originalEntity = new FacilityDto
+        {
+            Name = "Unique Test Facility",
+            Latitude = 40.779437,
+            Longitude = -73.963244,
+            Category = API.Dtos.FacilityCategory.WC
+        };
+        controller.Create(originalEntity);
+        
+        // Now try to create a duplicate
+        var duplicateEntity = new FacilityDto
+        {
+            Name = "Unique Test Facility", // Same name
+            Latitude = 41.0,
+            Longitude = -74.0,
+            Category = API.Dtos.FacilityCategory.Restaurant
+        };
+
+        // Act & Assert
+        Should.Throw<EntityValidationException>(() => controller.Create(duplicateEntity));
+    }
+
+    [Fact]
+    public void Updates()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
+        var updatedEntity = new FacilityDto
+        {
+            Id = -1,
+            Name = "Updated Central Park WC",
+            Latitude = 40.785091,
+            Longitude = -73.968285,
+            Category = API.Dtos.FacilityCategory.WC
+        };
+
+        // Act
+        var result = ((ObjectResult)controller.Update(updatedEntity).Result)?.Value as FacilityDto;
+
+        // Assert - Response
+        result.ShouldNotBeNull();
+        result.Id.ShouldBe(-1);
+        result.Name.ShouldBe(updatedEntity.Name);
+        result.UpdatedAt.ShouldNotBeNull();
+
+        // Assert - Database
+        var storedEntity = dbContext.Facility.FirstOrDefault(i => i.Id == -1);
+        storedEntity.ShouldNotBeNull();
+        storedEntity.Name.ShouldBe(updatedEntity.Name);
+        storedEntity.UpdatedAt.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void Update_fails_invalid_id()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var updatedEntity = new FacilityDto
+        {
+            Id = -1000,
+            Name = "Non-existent Facility",
+            Latitude = 40.779437,
+            Longitude = -73.963244,
+            Category = API.Dtos.FacilityCategory.Other
+        };
+
+        // Act & Assert
+        Should.Throw<NotFoundException>(() => controller.Update(updatedEntity));
+    }
+
+    [Fact]
+    public void Deletes()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+        var dbContext = scope.ServiceProvider.GetRequiredService<ToursContext>();
+
+        // Act
+        var result = (OkResult)controller.Delete(-3);
+
+        // Assert - Response
+        result.ShouldNotBeNull();
+        result.StatusCode.ShouldBe(200);
+
+        // Assert - Database
+        var storedEntity = dbContext.Facility.FirstOrDefault(i => i.Id == -3);
+        storedEntity.ShouldBeNull();
+    }
+    
+    [Fact]
+    public void Delete_fails_invalid_id()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+
+        // Act & Assert
+        Should.Throw<NotFoundException>(() => controller.Delete(-1000));
+    }
+    
+    private static FacilityController CreateController(IServiceScope scope)
+    {
+        return new FacilityController(scope.ServiceProvider.GetRequiredService<IFacilityService>())
+        {
+            ControllerContext = BuildContext("-1")
+        };
+    }
+}

--- a/src/Modules/Tours/Explorer.Tours.Tests/Integration/Administration/FacilityQueryTests.cs
+++ b/src/Modules/Tours/Explorer.Tours.Tests/Integration/Administration/FacilityQueryTests.cs
@@ -1,0 +1,39 @@
+using Explorer.API.Controllers.Administrator.Administration;
+using Explorer.BuildingBlocks.Core.UseCases;
+using Explorer.Tours.API.Dtos;
+using Explorer.Tours.API.Public.Administration;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Shouldly;
+
+namespace Explorer.Tours.Tests.Integration.Administration;
+
+[Collection("Sequential")]
+public class FacilityQueryTests : BaseToursIntegrationTest
+{
+    public FacilityQueryTests(ToursTestFactory factory) : base(factory) { }
+
+    [Fact]
+    public void Retrieves_all()
+    {
+        // Arrange
+        using var scope = Factory.Services.CreateScope();
+        var controller = CreateController(scope);
+
+        // Act
+        var result = ((ObjectResult)controller.GetAll(0, 0).Result)?.Value as PagedResult<FacilityDto>;
+
+        // Assert
+        result.ShouldNotBeNull();
+        result.Results.Count.ShouldBe(3);
+        result.TotalCount.ShouldBe(3);
+    }
+
+    private static FacilityController CreateController(IServiceScope scope)
+    {
+        return new FacilityController(scope.ServiceProvider.GetRequiredService<IFacilityService>())
+        {
+            ControllerContext = BuildContext("-1")
+        };
+    }
+}

--- a/src/Modules/Tours/Explorer.Tours.Tests/TestData/a-delete.sql
+++ b/src/Modules/Tours/Explorer.Tours.Tests/TestData/a-delete.sql
@@ -1,2 +1,3 @@
 ﻿DELETE FROM tours."Equipment";
 DELETE FROM tours."Problem";
+DELETE FROM tours."Facility";

--- a/src/Modules/Tours/Explorer.Tours.Tests/TestData/b-facility.sql
+++ b/src/Modules/Tours/Explorer.Tours.Tests/TestData/b-facility.sql
@@ -1,0 +1,11 @@
+INSERT INTO tours."Facility"(
+    "Id", "Name", "Latitude", "Longitude", "Category", "CreatedAt", "UpdatedAt", "IsDeleted")
+VALUES (-1, 'Central Park WC', 40.785091, -73.968285, 0, '2024-01-10T08:00:00Z', NULL, false);
+
+INSERT INTO tours."Facility"(
+    "Id", "Name", "Latitude", "Longitude", "Category", "CreatedAt", "UpdatedAt", "IsDeleted")
+VALUES (-2, 'Riverside Restaurant', 40.789722, -73.972778, 1, '2024-01-15T09:30:00Z', NULL, false);
+
+INSERT INTO tours."Facility"(
+    "Id", "Name", "Latitude", "Longitude", "Category", "CreatedAt", "UpdatedAt", "IsDeleted")
+VALUES (-3, 'Downtown Parking', 40.758896, -73.985130, 2, '2024-01-20T10:00:00Z', NULL, false);


### PR DESCRIPTION
📄 Pull Request Template za Backend <hr>
🎯 Change goal
User Story: As an Administrator I want to manage facility objects (create, view, update, delete) so that tourists can find useful facilities (WC, restaurants, parking, other) independent of tours they visit.
Acceptance Criteria:
•	Administrator can create a facility with name, latitude, longitude and category (WC, Restaurant, Parking, Other).
•	Administrator can list all facilities (paginated).
•	Administrator can update facility data.
•	Administrator can delete facility.
•	Endpoints are protected and accessible only to users with Administrator role.
<hr>
🗄️ Izmene nad bazom
Dodata tabela Facility u tours šemi:
CREATE TABLE IF NOT EXISTS tours."Facility" (
  "Id" BIGSERIAL PRIMARY KEY,
  "Name" VARCHAR(255) NOT NULL,
  "Latitude" DOUBLE PRECISION NOT NULL,
  "Longitude" DOUBLE PRECISION NOT NULL,
  "Category" INTEGER NOT NULL CHECK ("Category" IN (0,1,2,3)),
  "CreatedAt" TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
  "UpdatedAt" TIMESTAMP WITH TIME ZONE,
  "IsDeleted" BOOLEAN DEFAULT FALSE
);
Migracije koje je potrebno pokrenuti radi testiranja:
•	(optional) Add-Migration CreateFacilityTable -Project Modules/Tours/Explorer.Tours.Infrastructure
•	(optional) Update-Database -Project Modules/Tours/Explorer.Tours.Infrastructure
Seed skripta (putanja): SQL-Scripts/seed-facilities.sql
Primjer seed sadržaja:
INSERT INTO tours."Facility" ("Name","Latitude","Longitude","Category","CreatedAt","IsDeleted")
VALUES
  ('Javni WC - Trg Republike', 44.8167, 20.4611, 0, CURRENT_TIMESTAMP, FALSE),
  ('Restoran Stara Planina', 44.8156, 20.4622, 1, CURRENT_TIMESTAMP, FALSE),
  ('Parking Kalemegdan', 44.8244, 20.4489, 2, CURRENT_TIMESTAMP, FALSE);
<hr>
✅ Testiranje funkcionalnosti
Link do front-a: N/A
Preduslovi:
1.	Pokrenuti aplikaciju: dotnet run --project Explorer.API
2.	Otvoriti Swagger UI: http://localhost:5000/swagger
Autentifikacija:
1.	POST /api/users/login sa:
{ "username": "pera", "password": "pera" }
2.	Kopirati accessToken
3.	Swagger → Authorize → Bearer {accessToken} → Authorize → Close
Manualni testovi:
GET — pregled:
•	Endpoint: GET /api/administration/facility
•	Query: page=0, pageSize=0 (sve stavke)
•	Očekivano: 200, lista facilities
POST — kreiranje:
•	Endpoint: POST /api/administration/facility
•	Body:
{
  "name": "Test WC Centar",
  "latitude": 44.8167,
  "longitude": 20.4611,
  "category": 0
}
•	Očekivano: 200, vraćen objekat sa id
PUT — izmena:
•	Endpoint: PUT /api/administration/facility/{id}
•	Body (id u URL i u body mora odgovarati):
{
  "id": 1,
  "name": "Updated WC Name",
  "latitude": 44.8170,
  "longitude": 20.4615,
  "category": 0
}
•	Očekivano: 200, vraćen ažurirani objekat
DELETE — brisanje:
•	Endpoint: DELETE /api/administration/facility/{id}
•	Očekivano: 200 (ili 204), entitet uklonjen
Autorizacija:
•	Logout u Swagger → pokušaj poziva bez tokena → očekivano 401 Unauthorized
•	Ako korisnik nema administrator ulogu → očekivano 403 Forbidden
Automatski testovi:
dotnet test Modules\Tours\Explorer.Tours.Tests\Explorer.Tours.Tests.csproj --filter "FullyQualifiedName~Facility"
Očekivano: svi Facility testovi prolaze
<hr>
Izmijenjeni fajlovi (pregled):
•	Modules/Tours/Explorer.Tours.Core/Domain/Facility.cs — entitet
•	Modules/Tours/Explorer.Tours.API/Dtos/FacilityDto.cs — DTO
•	Modules/Tours/Explorer.Tours.API/Public/Administration/IFacilityService.cs — servis interfejs
•	Modules/Tours/Explorer.Tours.Core/UseCases/Administration/FacilityService.cs — servis implementacija
•	Modules/Tours/Explorer.Tours.Core/Domain/RepositoryInterfaces/IFacilityRepository.cs — repo interfejs
•	Modules/Tours/Explorer.Tours.Infrastructure/Database/Repositories/FacilityDbRepository.cs — repo implementacija
•	Modules/Tours/Explorer.Tours.Infrastructure/Database/ToursContext.cs — dodan DbSet<Facility>
•	Modules/Tours/Explorer.Tours.Infrastructure/ToursStartup.cs — DI registracija
•	Explorer.API/Controllers/Administrator/Administration/FacilityController.cs — API kontroler
•	Modules/Tours/Explorer.Tours.Tests/TestData/a-delete.sql — test cleanup
•	Modules/Tours/Explorer.Tours.Tests/TestData/b-facility.sql — test seed