### PR TITLE
feat/BlogStatus+extending

### DIFF
--- a/src/Explorer.API/Controllers/BlogController.cs
+++ b/src/Explorer.API/Controllers/BlogController.cs
@@ -1,3 +1,5 @@
+using System.IO.Compression;
+using System.Linq.Expressions;
 using Explorer.Blog.API.Public;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -36,8 +38,46 @@ public class BlogController : ControllerBase
     [HttpPut("{id}")]
     public ActionResult<BlogDto> UpdateBlog(long id, [FromBody] BlogUpdateDto blogDto) // Editovanje bloga
     {
-        var result = _blogService.UpdateBlog(id, blogDto);
-        
-        return Ok(result);
+        try
+        {
+            var result = _blogService.UpdateBlog(id, blogDto);
+            return Ok(result);
+        }
+        catch (InvalidOperationException e)
+        {
+            return BadRequest(e.Message);
+        }
+        catch (ArgumentException e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpPut("{id}/publish")]
+    public ActionResult<BlogDto> Publish(long id)
+    {
+        try
+        {
+            var result = _blogService.PublishBlog(id);
+            return Ok(result);
+        }
+     catch (InvalidOperationException e)
+        {
+            return BadRequest(e.Message);
+        }
+    }
+
+    [HttpPut("{id}/archive")]
+    public ActionResult<BlogDto> Archive(long id)
+    {
+        try
+        {
+            var result = _blogService.ArchiveBlog(id);
+            return Ok(result);
+        }
+        catch (InvalidOperationException e)
+        {
+            return BadRequest(e.Message);
+        }
     }
 }

--- a/src/Modules/Blog/Explorer.Blog.API/Public/BlogDto.cs
+++ b/src/Modules/Blog/Explorer.Blog.API/Public/BlogDto.cs
@@ -8,4 +8,6 @@ public class BlogDto
     public string Description {get; set;}
     public DateTime CreationDate {get; set;}
     public List<string> Images {get; set;}
+    public string Status {get; set;}
+    public DateTime? LastModifiedDate {get; set;}
 }

--- a/src/Modules/Blog/Explorer.Blog.API/Public/IBlogService.cs
+++ b/src/Modules/Blog/Explorer.Blog.API/Public/IBlogService.cs
@@ -5,4 +5,7 @@ public interface IBlogService
     BlogDto CreateBlog(long userId, BlogCreateDto blogDto);
     List<BlogDto> GetUserBlogs(long userId);
     BlogDto UpdateBlog(long blogId, BlogUpdateDto blogDto);
+
+    BlogDto PublishBlog(long blogId);
+    BlogDto ArchiveBlog(long blogId);
 }

--- a/src/Modules/Blog/Explorer.Blog.Core/Domain/Blog.cs
+++ b/src/Modules/Blog/Explorer.Blog.Core/Domain/Blog.cs
@@ -10,6 +10,9 @@ public class Blog : Entity
     public DateTime CreationDate {get; private set;}
     public List<string> Images {get; private set;}
 
+    public BlogStatus Status {get; private set;}
+    public DateTime? LastModifiedDate {get; private set;}
+
     public Blog(long userId, string title, string description, List<string>? images = null)
     {
         UserId = userId;
@@ -17,6 +20,7 @@ public class Blog : Entity
         Description = description ?? throw new ArgumentNullException(nameof(description));
         CreationDate = DateTime.UtcNow;
         Images = images ?? new List<string>();
+        Status = BlogStatus.Draft; // Kada korisnik kreira blog, on se nalazi u stanju pripreme.
         Validate();
     }
 
@@ -27,12 +31,47 @@ public class Blog : Entity
         if (string.IsNullOrWhiteSpace(Description)) throw new ArgumentException("Description can't be empty");
     }
 
-    public void Update(string title, string description, List<string>? images) // Korisnik moze izmeniti naslov, opis i slike
+    public void Update(string title, string description, List<string>? images) // Updated Update logic
     {
-        Title = title ?? Title;
-        Description = description ?? Description;
-        Images = images ?? Images;
-        Validate();
+        if (Status == BlogStatus.Archived || Status == BlogStatus.Closed)
+        {
+            throw new InvalidOperationException("Cannot update a blog that is archived or closed.");
+        }
+
+        if (Status == BlogStatus.Published) // "Autor može da ažurira samo opis za objavljen blog"
+        {
+            if (Title != title) throw new InvalidOperationException ("Cannot change the title of a published blog."); 
+
+            Description = description;
+        }
+        else if (Status == BlogStatus.Draft) // Tokom pripreme autor može da podešava naziv, opis i slike bloga.
+        {
+            Title = title;
+            Description = description;
+            Images = images;
+        }
+
+        LastModifiedDate = DateTime.UtcNow; // Pamti se vreme poslednje izmene za svako ažuriranje
     }
     
+    public void Publish() // U momentu kada je autor zadovoljan, može da objavi blog.
+    {
+        if (Status != BlogStatus.Draft)
+        {
+            throw new InvalidOperationException("Only drafts can be published");
+        }
+        Status = BlogStatus.Published;
+        LastModifiedDate = DateTime.UtcNow;
+    }
+
+    public void Archive() // utor može da arhivira blog koji je objavljen, nakon čega nije moguće menjati sadržaj.
+    {
+        if (Status != BlogStatus.Published)
+        {
+            throw new InvalidOperationException("Only published blogs can be archived.");
+        }
+        Status = BlogStatus.Archived;
+        LastModifiedDate = DateTime.UtcNow;
+    }
+
 }

--- a/src/Modules/Blog/Explorer.Blog.Core/Domain/BlogStatus.cs
+++ b/src/Modules/Blog/Explorer.Blog.Core/Domain/BlogStatus.cs
@@ -1,0 +1,11 @@
+namespace Explorer.Blog.Core.Domain;
+
+public enum BlogStatus
+{
+    Draft, // default
+    Published,
+    Archived, 
+    Closed, // score < -10
+    Active, // score > 100 or commenst > 10
+    Famous // score > 500 & comments > 30
+}

--- a/src/Modules/Blog/Explorer.Blog.Core/UseCases/BlogService.cs
+++ b/src/Modules/Blog/Explorer.Blog.Core/UseCases/BlogService.cs
@@ -31,7 +31,23 @@ public class BlogService : IBlogService
     public BlogDto UpdateBlog(long blogId, BlogUpdateDto blogDto)
     {
         var blog = _blogRepository.GetById(blogId);
-        blog.Update(blogDto.Title, blogDto.Description, blogDto.Images);
+        blog.Update(blogDto.Title, blogDto.Description, blogDto.Images); // The Aggregate (Blog.cs) now throws an exception if this is Invalid.
+        var updatedBlog = _blogRepository.Update(blog);
+        return _mapper.Map<BlogDto>(updatedBlog);
+    }
+
+    public BlogDto PublishBlog(long  blogId)
+    {
+        var blog = _blogRepository.GetById(blogId);
+        blog.Publish(); // Changes the status of the blog to Published
+        var updatedBlog = _blogRepository.Update(blog);
+        return _mapper.Map<BlogDto>(updatedBlog);
+    }
+     
+     public BlogDto ArchiveBlog(long blogId)
+    {
+        var blog = _blogRepository.GetById(blogId);
+        blog.Archive(); // Changes the status of the blog to Archived
         var updatedBlog = _blogRepository.Update(blog);
         return _mapper.Map<BlogDto>(updatedBlog);
     }

--- a/src/Modules/Blog/Explorer.Blog.Infrastructure/Database/BlogContext.cs
+++ b/src/Modules/Blog/Explorer.Blog.Infrastructure/Database/BlogContext.cs
@@ -12,5 +12,11 @@ public class BlogContext : DbContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasDefaultSchema("blog");
+
+        modelBuilder.Entity<Core.Domain.Blog>().Property(b => b.Images).HasColumnType("text[]");
+
+        modelBuilder.Entity<Core.Domain.Blog>().Property(b => b.Status).IsRequired();
+
+        modelBuilder.Entity<Core.Domain.Blog>().Property(b => b.LastModifiedDate).IsRequired(false); // nullable bcs the blog doesn't have to be updated if it's not needed
     }
 }


### PR DESCRIPTION
Added BlogStatus enum that contains all of the possible Blog statuses
Added Status/LastModifiedDate properties to Blog.cs
Update logic inside of Blog.cs updated (pun not intended) to use the aggregate rule and what the functionality is asking for
Added Publish/Archive inside of Blog.cs
Extended BlogContext.cs with Status and LastModifiedDate, required and not required fields
Added Status/LastModifiedDate proprties to BlogDto.cs
Added BlogDto PublishBlog/BlogDto ArchiveBlog to IBlogService.cs
Implemented BlogDto PublishBlog/BlogDto ArchiveBlog in BlogService.cs + quick note, the aggregate now throws an exception if Update is invalid
Extended BlogController.cs with Publish and Archive + added try/catch to handle InvalidOperationException -> error code 400 since the aggregate rules are violated
