### PR TITLE
fix: Add IsRequired for TourId in tour keypoints

### DIFF
--- a/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/ToursContext.cs
+++ b/src/Modules/Tours/Explorer.Tours.Infrastructure/Database/ToursContext.cs
@@ -38,6 +38,7 @@ public class ToursContext : DbContext
             .HasMany(e => e.Keypoints)
             .WithOne()
             .HasForeignKey("TourId")
+            .IsRequired()
             .OnDelete(DeleteBehavior.Cascade);
 
         modelBuilder.Entity<Tour>()


### PR DESCRIPTION
📄 **Fix za brisanje keypoints**
<hr>

🎯 **Change goal**  
Ispravka da se TourId u Keypoints tabeli ne popuni samo sa null vrednosti umesto da se ceo red obriše.
<hr>

🗄️ **Izmene nad bazom**  
TourId je sada required polje u Keypoints tabeli

**Migracije koje je potrebno pokrenuti radi testiranja:**  
data reseter

✅ **Testiranje funkcionalnosti**  
1. Ulogovati se kao author1
2. Dodati keypoint na turu 1
3. Obrisati taj keypoint
4. Proveriti da li je null u bazi ili je obrisan red
